### PR TITLE
Reduce clang-tidy warnings

### DIFF
--- a/lib/buffer/buffer.h
+++ b/lib/buffer/buffer.h
@@ -53,9 +53,9 @@
 #define R_SENSE 0.11f // Match to your driver
 
 #define SPEED 300 // speed (r/min)
-constexpr int32_t MOVE_DIVIDE_NUM = 64;
-constexpr uint32_t VACTUAL_VALUE = static_cast<uint32_t>(static_cast<float>(SPEED) * MOVE_DIVIDE_NUM * 200.0f / 60.0f /
-                                                         0.715f);
+inline constexpr int32_t MOVE_DIVIDE_NUM = 64;
+inline constexpr uint32_t VACTUAL_VALUE = static_cast<uint32_t>(static_cast<float>(SPEED) * MOVE_DIVIDE_NUM * 200.0f /
+                                                                60.0f / 0.715f);
 
 #define STOP 0 // stop
 #define I_CURRENT (600) // motor current
@@ -94,11 +94,5 @@ extern void buffer_init();
 extern void buffer_loop();
 extern void timer_it_callback();
 extern void buffer_debug();
-
-extern bool is_error;
-extern uint32_t front_time; // forward time
-extern uint32_t timeout;
-extern bool is_front;
-extern TMC2209Stepper driver;
 
 #endif // LIB_BUFFER_BUFFER_H


### PR DESCRIPTION
## Summary
- address several clang-tidy issues
- move serial buffer and hardware timer to local scope
- update constants and loops for readability

## Testing
- `pio run -e fly_buffer_f072c8`
- `pio check`

------
https://chatgpt.com/codex/tasks/task_e_685c7540d88883208bfc312a03c7fdb5