### PR TITLE
Fix short press logic for multi-press behavior

### DIFF
--- a/lib/buffer/buffer.cpp
+++ b/lib/buffer/buffer.cpp
@@ -285,7 +285,12 @@ auto handleButton(uint8_t pin, Motor_State dir, uint32_t &last_time, uint8_t &co
     is_front = false;
     front_time = 0;
     is_timeout = true;
-    count = 0;
+    if (count >= MULTI_PRESS_COUNT) {
+      continuous_run = true;
+      continuous_direction = dir;
+      is_timeout = false;
+      count = 0;
+    }
     return true;
   }
 


### PR DESCRIPTION
## Summary
- allow multi-press detection when button is tapped briefly
- retain combo count without stopping the motor

## Testing
- `clang-format -i lib/buffer/buffer.cpp lib/buffer/buffer.h src/main.cpp`
- `pio run -e fly_buffer_f072c8`
- `pio check`


------
https://chatgpt.com/codex/tasks/task_e_685dcce66de48320921027a1d2799714