### PR TITLE
Add speed configuration and move command

### DIFF
--- a/lib/buffer/buffer.h
+++ b/lib/buffer/buffer.h
@@ -55,7 +55,6 @@ inline constexpr double SPEED_MM_S = 30.0;
 inline constexpr double SPEED_MULTIPLIER = 9.1463414634;
 inline constexpr double SPEED_RPM = SPEED_MM_S * SPEED_MULTIPLIER; // speed in r/min
 inline constexpr int32_t MOVE_DIVIDE_NUM = 16;
-inline constexpr uint32_t VACTUAL_VALUE = static_cast<uint32_t>(SPEED_RPM * MOVE_DIVIDE_NUM * 200.0f / 60.0f / 0.715f);
 
 #define STOP 0 // stop
 #define I_CURRENT (600) // motor current


### PR DESCRIPTION
## Summary
- support configurable speed via `set_speed` command
- add `move <mm>` command for moving a specific distance
- report current speed on query and after setting
- stop continuous/move operation when filament is absent
- compute motor speed from configured mm/s

## Testing
- `clang-format -i lib/buffer/*.cpp lib/buffer/*.h src/*.cpp src/*.h`
- `pio run -e fly_buffer_f072c8` *(fails: section `.data` will not fit in region `FLASH`)*
- `pio check`

------
https://chatgpt.com/codex/tasks/task_e_68715a1658108320916946d91b57471d